### PR TITLE
Update README.md; SWING: note about non-integer values for DIV

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If TRG IN is connected, Fence will not work continously but more like a S&H when
 
 Swing is a micro timing sequencer generating a micro timed clock to implement custom micro timing the easy way.
 
-DIV controls how many beats are created for one clock in trg. 
+DIV controls how many beats are created for one clock in trg. Note that moving the knob you can dial in non-integer values but the mantisa (fractional part) will not be displayed. Right click and set using the keyboard to get exact integers.
 LEN controls how many of the 16 timing settings will be applied before looping back to the first one.
 Default setup is DIV 4 and LEN 16 which is fine for 16 16th of a 4/4 bar. For a simple swing LEN 2 is sufficient. You only have to dial in the first 2 knobs in this case.
 AMT controls how much the timing knobs will influence the timing. AMT = 0% switches micro timing off.


### PR DESCRIPTION
Hiya - this confused me for an hour so thought I'd update the README to help others. I was about to submit a bug report then realised that the wonky timing I was hearing was due to a non-integer value for DIV!

What do you think about having a right-click menu option in SWING to enable/disable non-integer values for DIV? I would assume that most people will be using integer values (non integers are not very musical to my ears) so could default this to "on" to save anyone future confusion?

Cheers!