### PR TITLE
Fix Hold polyphonic CV row mapping

### DIFF
--- a/src/Hold.cpp
+++ b/src/Hold.cpp
@@ -69,7 +69,7 @@ struct Hold : Module
 
         for (int i = 0; i < NUM_ROWS; i++) 
 		{
-            setInPoly (CV_INPUT, true);
+            setInPoly (CV_INPUT + i, true);
             setOutPoly(CV_OUTPUT + i, true);
         }
 	}
@@ -186,19 +186,23 @@ struct Hold : Module
 		// Now do the real processing
 		int gateChannels = inputs[GATE_INPUT].getChannels();
 		float gate = 0.0f;
+		int cvInput = -1;
         for (int row = 0; row < NUM_ROWS; row++)
         {
 			// check for active gate
 			if (row < gateChannels) {
 				gate = OL_statePoly[GATE_INPUT + row];
 			}
+			if (getInputConnected(CV_INPUT + row)) {
+				cvInput = CV_INPUT + row;
+			}
 
 			// Skip rows with no cv input connected
-			if (getInputConnected(CV_INPUT + row)) {
-				int channels = inputs[CV_INPUT + row].getChannels();
+			if (cvInput >= 0) {
+				int channels = inputs[cvInput].getChannels();
 		        for (int channel = 0; channel < channels; channel++)
         		{
-					float cv = OL_statePoly[CV_INPUT * POLY_CHANNELS + channel];
+					float cv = OL_statePoly[cvInput * POLY_CHANNELS + channel];
 					if (gate > 5.0f) {
 						if (getStateParam(TRK_ON_PARAM) == 1.0f ||	// gate for track and hold
 					   	    oldGates[row] < 5.0f					// rising edge for sample and hold
@@ -208,7 +212,7 @@ struct Hold : Module
 					}
 					setStateOutPoly(CV_OUTPUT + row, channel, getStateJson(STORE_JSON + row * POLY_CHANNELS + channel));
 				}
-				setOutPolyChannels(CV_OUTPUT + row * POLY_CHANNELS, channels);
+				setOutPolyChannels(CV_OUTPUT + row, channels);
 			}
 			// remember gate for rising edge detection in s&h mode
 			oldGates[row] = gate;


### PR DESCRIPTION
This module is exactly what I was looking for. Great timing.

Only the polyphonic behavior was not as I expected. Without documentation I didn't know if it was a bug or not. 

I couldn't trigger on channel 2 of Gate input, a polyphonic S&H on row 2.
 
I had it fixed, forked and PR'ed by AI (sorry for that).

  Changes:
  - Mark each row CV input as polyphonic.
  - Read CV data from the matching row input.
  - Set output poly channel counts on the matching row output.
  
  If my interpretation of the module its functionality is incorrect, I apologize of the inconvenience.